### PR TITLE
Fixes for infra build

### DIFF
--- a/infra/base-clang-11.0.0/checkout_build_install_llvm.sh
+++ b/infra/base-clang-11.0.0/checkout_build_install_llvm.sh
@@ -21,7 +21,8 @@ LLVM_DEP_PACKAGES="\
     python2.7 \
     binutils-gold \
     binutils-dev \
-    wget"
+    wget \
+    bc"
 apt-get update
 apt-get install -y $LLVM_DEP_PACKAGES
 
@@ -63,6 +64,7 @@ cd /tmp/llvm
 cmake -G "Ninja" \
   -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
   -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" \
+  -DLLVM_PARALLEL_LINK_JOBS=$(echo "$(free -b | head -n2 | tail -n1 | tr -s ' ' | cut -d ' ' -f 2) / $((8 << 30))" | bc) \
   -DLLVM_FORCE_ENABLE_STATS=ON -DLLVM_BINUTILS_INCDIR=/usr/include $SRC/llvm
 ninja -j $(nproc)
 ninja install

--- a/infra/base-clang-11.0.0/checkout_build_install_llvm.sh
+++ b/infra/base-clang-11.0.0/checkout_build_install_llvm.sh
@@ -64,7 +64,7 @@ cmake -G "Ninja" \
   -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
   -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" \
   -DLLVM_FORCE_ENABLE_STATS=ON -DLLVM_BINUTILS_INCDIR=/usr/include $SRC/llvm
-ninja -j 4
+ninja -j $(nproc)
 ninja install
 rm -rf /tmp/llvm
 

--- a/infra/base-sim/Dockerfile
+++ b/infra/base-sim/Dockerfile
@@ -29,7 +29,9 @@ COPY scripts/ $SCRIPTS/
 COPY opentitan-requirements.txt sim-requirements.txt $SRC/
 
 # Install python dependencies
-RUN apt-get update && apt-get install -y git xxd
+RUN apt-get update && apt-get install -y git xxd python3.7-dev
+RUN rm /usr/bin/python3
+RUN ln -s $(which python3.7) /usr/bin/python3
 
 # Install OpenTitan and Python Dependencies
 RUN python3 -m pip install -r $SRC/opentitan-requirements.txt
@@ -49,7 +51,7 @@ RUN apt-get update && apt-get install -y \
       libiberty-dev \
       libssl-dev
 RUN cd $SRC && git clone --depth=1 https://github.com/SimonKagstrom/kcov
-RUN cd $SRC/kcov && mkdir build && cd build && cmake .. && make
+RUN cd $SRC/kcov && mkdir build && cd build && cmake .. && make -j $(nproc)
 
 # Remove uneeded packages and requirements files
 RUN apt-get remove --purge -y git && apt-get autoremove -y

--- a/infra/base-sim/opentitan-requirements.txt
+++ b/infra/base-sim/opentitan-requirements.txt
@@ -1,3 +1,4 @@
+MarkupSafe==2.0.0
 Mako==1.1.3
 
 # Development version with OT-specific changes

--- a/infra/base-verilator/checkout_build_install_verilator.sh
+++ b/infra/base-verilator/checkout_build_install_verilator.sh
@@ -30,7 +30,7 @@ git checkout 7be343fd7c885359ac29e50e9732509caf64637d
 autoconf
 export VERILATOR_ROOT=$(pwd)
 ./configure
-make -j 4
+make -j $(nproc)
 make install
 
 # Remove installation dependencies to shrink image size


### PR DESCRIPTION
Multiple python packages have upgraded in such a way that they are no longer compatible with Ubuntu 18.04, at least as used here. This PR provides the necessary changes to a) successfully complete the docker build for all of the base images and b) improve build time by utilising CPUs more effectively.